### PR TITLE
Rename Software.software_versions to versions

### DIFF
--- a/pyfarm/master/api/software.py
+++ b/pyfarm/master/api/software.py
@@ -52,12 +52,12 @@ class VersionParseError(Exception):
 
 def extract_version_dicts(json_in):
     out = []
-    version_objects = json_in.pop("software_versions", [])
+    version_objects = json_in.pop("versions", [])
     if not isinstance(version_objects, list):
-        raise VersionParseError("Column software_versions must be a list.")
+        raise VersionParseError("Column versions must be a list.")
     for software_obj in version_objects:
         if not isinstance(software_obj, dict):
-            raise VersionParseError("""Entries in software_versions must be
+            raise VersionParseError("""Entries in versions must be
                 dictionaries.""")
         if not isinstance(software_obj["version"], STRING_TYPES):
             raise VersionParseError("Software versions must be strings.")
@@ -139,7 +139,7 @@ class SoftwareIndexAPI(MethodView):
                 {
                     "id": 4,
                     "software": "blender",
-                    "software_versions": []
+                    "versions": []
                 }
 
         :statuscode 201: a new software item was created
@@ -203,7 +203,7 @@ class SoftwareIndexAPI(MethodView):
                     {
                         "software": "Houdini",
                         "id": 1,
-                        "software_versions": [
+                        "versions": [
                             {
                                 "version": "13.0.1",
                                 "id": 1,
@@ -258,7 +258,7 @@ class SingleSoftwareAPI(MethodView):
                 {
                     "id": 4,
                     "software": "blender",
-                    "software_versions": []
+                    "versions": []
                 }
 
             **Request**
@@ -270,7 +270,7 @@ class SingleSoftwareAPI(MethodView):
 
                 {
                     "software": "blender",
-                    "software_version": [
+                    "version": [
                         {
                             "version": "1.69"
                         }
@@ -287,7 +287,7 @@ class SingleSoftwareAPI(MethodView):
                 {
                     "id": 4,
                     "software": "blender",
-                    "software_versions": [
+                    "versions": [
                         {
                             "version": "1.69",
                             "id": 1,
@@ -325,8 +325,8 @@ class SingleSoftwareAPI(MethodView):
 
         software.software = g.json["software"]
 
-        if "software_versions" in g.json:
-            software.software_versions = []
+        if "versions" in g.json:
+            software.versions = []
             db.session.flush()
             versions = extract_version_dicts(g.json)
             current_rank = 100
@@ -369,7 +369,7 @@ class SingleSoftwareAPI(MethodView):
                 {
                     "software": "Autodesk Maya",
                     "id": 1,
-                    "software_versions": [
+                    "versions": [
                         {
                             "version": "2013",
                             "id": 1,
@@ -478,7 +478,7 @@ class SoftwareVersionsIndexAPI(MethodView):
             return jsonify(error="Requested software not found"), NOT_FOUND
 
         out = [{"version": x.version, "id": x.id, "rank": x.rank}
-               for x in software.software_versions]
+               for x in software.versions]
         return jsonify(out), OK
 
     @validate_with_model(SoftwareVersion, ignore=("software_id", "rank"),
@@ -490,7 +490,7 @@ class SoftwareVersionsIndexAPI(MethodView):
         A rank can optionally be included.  If it isn't, it is assumed that this
         is the newest version for this software
 
-        .. http:post:: /api/v1/software/ HTTP/1.1
+        .. http:post:: /api/v1/software/versions/ HTTP/1.1
 
             **Request**
 
@@ -516,7 +516,7 @@ class SoftwareVersionsIndexAPI(MethodView):
                     "rank": "100"
                 }
 
-        :statuscode 201: a new software verison was created
+        :statuscode 201: a new software version was created
         :statuscode 400: there was something wrong with the request (such as
                             invalid columns being included)
         :statuscode 409: a software version with that name already exists

--- a/pyfarm/models/core/mixins.py
+++ b/pyfarm/models/core/mixins.py
@@ -176,7 +176,7 @@ class UtilityMixins(object):
                 values.append(relationship.name)
             elif name == "software":
                 values.append(relationship.name)
-            elif name == "software_versions":
+            elif name == "versions" or name == "software_versions":
                 values.append({"id": relationship.id,
                                "version": relationship.version,
                                "rank": relationship.rank})

--- a/pyfarm/models/software.py
+++ b/pyfarm/models/software.py
@@ -53,13 +53,13 @@ class Software(db.Model, UtilityMixins):
                          doc=dedent("""
                          The name of the software"""))
 
-    software_versions = db.relationship("SoftwareVersion",
-                                        backref=db.backref("software"),
-                                        lazy="dynamic",
-                                        cascade="all, delete-orphan",
-                                        order_by="asc(SoftwareVersion.rank)",
-                                        doc="All known versions of this "
-                                            "software")
+    versions = db.relationship("SoftwareVersion",
+                               backref=db.backref("software"),
+                               lazy="dynamic",
+                               cascade="all, delete-orphan",
+                               order_by="asc(SoftwareVersion.rank)",
+                               doc="All known versions of this "
+                                   "software")
 
 
 class SoftwareVersion(db.Model, UtilityMixins):

--- a/tests/test_master/test_software_api.py
+++ b/tests/test_master/test_software_api.py
@@ -50,13 +50,13 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                                     {"version": "1.0"}
                             ]
                        }))
         self.assert_created(response1)
         id = response1.json['id']
-        version_id = response1.json["software_versions"][0]["id"]
+        version_id = response1.json["versions"][0]["id"]
 
         response2 = self.client.get("/api/v1/software/%d" % id)
         self.assert_ok(response2)
@@ -64,7 +64,7 @@ class TestSoftwareAPI(BaseTestCase):
             response2.json, {
                             "id": id,
                             "software": "foo", 
-                            "software_versions": [
+                            "versions": [
                                     {
                                     "id": version_id,
                                     "rank": 100,
@@ -79,7 +79,7 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                                     {
                                         "version": 1,
                                         "bad_key": "bla"
@@ -94,7 +94,7 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                                     {
                                         "version": "1.0",
                                         "rank": 100
@@ -130,7 +130,7 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                             {"version": "1.0"}
                         ]
                        }))
@@ -142,7 +142,7 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                                 {"version": "1.0"}
                             ]
                        }))
@@ -154,13 +154,13 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                         "software": "foo",
-                        "software_versions": [
+                        "versions": [
                                 {"version": "1.0"}
                             ]
                        }))
         self.assert_ok(response2)
         id = response2.json['id']
-        version_id = response2.json["software_versions"][0]["id"]
+        version_id = response2.json["versions"][0]["id"]
 
         response3 = self.client.get("/api/v1/software/foo")
         self.assert_ok(response3)
@@ -168,7 +168,7 @@ class TestSoftwareAPI(BaseTestCase):
             response3.json, {
                             "id": id,
                             "software": "foo", 
-                            "software_versions": [
+                            "versions": [
                                     {
                                     "id": version_id,
                                     "rank": 100,
@@ -228,7 +228,7 @@ class TestSoftwareAPI(BaseTestCase):
             response3.json, {
                             "id": id,
                             "software": "foo", 
-                            "software_versions": [
+                            "versions": [
                                 {
                                     "id": version_id,
                                     "rank": 100,
@@ -243,14 +243,14 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                 "software": "foo",
-                            "software_versions": [
+                            "versions": [
                                 {"version": "1.0"},
                                 {"version": "1.1"}
                             ]
                        }))
         self.assert_created(response1)
-        version1_id = response1.json["software_versions"][0]["id"]
-        version2_id = response1.json["software_versions"][1]["id"]
+        version1_id = response1.json["versions"][0]["id"]
+        version2_id = response1.json["versions"][1]["id"]
 
         response2 = self.client.get("/api/v1/software/foo/versions/")
         self.assert_ok(response2)
@@ -274,7 +274,7 @@ class TestSoftwareAPI(BaseTestCase):
             content_type="application/json",
             data=dumps({
                 "software": "foo",
-                "software_versions": [
+                "versions": [
                         {"version": "1.0"}
                     ]
                 }))


### PR DESCRIPTION
The relationship is already part of the Software class, so calling it
software_versions is just being unnecessarily wordy.

The same relation in Agent should not be renamed.  In that class, the
longer name is necessary to avoid ambiguity.
