### PR TITLE
Use the job's priority for new tasks

### DIFF
--- a/pyfarm/master/api/jobs.py
+++ b/pyfarm/master/api/jobs.py
@@ -342,6 +342,7 @@ class JobIndexAPI(MethodView):
             task = Task()
             task.job = job
             task.frame = current_frame
+            task.priority = job.priority
             db.session.add(task)
             current_frame += by
 
@@ -622,6 +623,7 @@ class SingleJobAPI(MethodView):
                 task = Task()
                 task.job = job
                 task.frame = frame
+                task.priority = job.priority
                 db.session.add(task)
 
         if "time_started" in g.json:


### PR DESCRIPTION
When creating new tasks, use the job's priority as the default priority.
When changing an existing job's priority, its tasks' priorities will
still not be updated, though.  This is by design.
