### PR TITLE
Don't unpack agent relations on POST to single

### DIFF
--- a/pyfarm/master/api/agents.py
+++ b/pyfarm/master/api/agents.py
@@ -539,7 +539,7 @@ class SingleAgentAPI(MethodView):
         db.session.commit()
         assign_tasks.delay()
 
-        return jsonify(model.to_dict()), OK
+        return jsonify(model.to_dict(unpack_relationships=False)), OK
 
     def delete(self, agent_id):
         """


### PR DESCRIPTION
This instance of agent relations unpacking was missed in the recently
merged branch.
