### PR TITLE
Fix Missing Imports

### DIFF
--- a/pyfarm/master/api/tasklogs.py
+++ b/pyfarm/master/api/tasklogs.py
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover
 
 import tempfile
 from os import makedirs
-from os.path import join, isfile, realpath
+from os.path import join, realpath
 from errno import EEXIST
 
 from flask.views import MethodView


### PR DESCRIPTION
This change fixes a missing import that came up with I created a buildbot instance for testing OSX and Windows (building out a vm for Windows still):

https://build.pyfarm.net/builders/master-postgres-mac-2.7/builds/8/steps/run%20tests/logs/stdio

This came up because we're receiving a `BAD_REQUEST` response on OS X which is not something we're getting on Linux and the `BAD_REQUEST` object itself is not being imported. Unfortunately, the tests are still failing however (though for other reasons it appears):

https://build.pyfarm.net/builders/master-postgres-mac-2.7/builds/9/steps/run%20tests/logs/stdio

The change fixes the missing import but not the general test failure since that requires further debugging and it may just be because that build slave is not setup correctly.
