### PR TITLE
Fix finding new version for jobtype update via API

### DIFF
--- a/pyfarm/master/api/jobtypes.py
+++ b/pyfarm/master/api/jobtypes.py
@@ -456,7 +456,7 @@ class SingleJobTypeAPI(MethodView):
                 "jobtype %s will get a new version with data %r on commit",
                 jobtype.name, g.json)
             max_version, = db.session.query(func.max(
-                JobTypeVersion.version)).first()
+                JobTypeVersion.version)).filter_by(jobtype=jobtype).first()
         else:
             jobtype = JobType()
 


### PR DESCRIPTION
This change will make the code look only at the maximum version number
for this particular jobtype when calculating a new version number
instead of the maximum version number of all jobtypes in the system.
