### PR TITLE
Unjumble date and user columns

### DIFF
--- a/pyfarm/master/templates/pyfarm/user_interface/jobs.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/jobs.html
@@ -129,7 +129,6 @@
     </td>
     <td><a href="{{ url_for('single_job_ui', job_id=job[0].id) }}">{{ job[0].title }}</a></td>
     <td>{{ job[0].user.username }}</td>
-    <td>{{ job[0].time_submitted }}</td>
     <td>
       <nobr>{{ job.t_queued }}/{{ job.t_running }}/{{ job.t_failed }}/{{ job.t_done }}</nobr><br/>
       <div class="progress">
@@ -144,6 +143,7 @@
         </div>
       </div>
     </td>
+    <td>{{ job[0].time_submitted.strftime('%Y-%m-%d %H:%M:%S UTC') }}</td>
     <td>{{ 'deleting' if job[0].to_be_deleted else job[0].state }}</td>
     <td>
       {% for tag in job[0].tags %}


### PR DESCRIPTION
A recent commit has jumbled the date and user columns. This puts them in
the right order again.
