### PR TITLE
Change the default sort of jobs to submitted, descending

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -96,8 +96,8 @@ def jobs():
             jobs_query = jobs_query.filter(
                 Job.title.ilike("%%%s%%" % title))
 
-    order_dir = "asc"
-    order_by = "title"
+    order_dir = "desc"
+    order_by = "time_submitted"
     if "order_by" in request.args:
         order_by = request.args.get("order_by")
     if order_by not in ["title", "state", "time_submitted", "t_queued",


### PR DESCRIPTION
User feedback suggests that this is a more sensible default; users will
usually, most of the time, look for the job they submitted last, so
putting that one to the top could help.
