### PR TITLE
Optionally listen on 0.0.0.0 in standalone mode

### DIFF
--- a/pyfarm/master/entrypoints.py
+++ b/pyfarm/master/entrypoints.py
@@ -599,7 +599,11 @@ def run_master():  # pragma: no cover
 
     load_setup(app)
     load_master(app, admin, api)
-    app.run()
+
+    if read_env_bool("PYFARM_DEV_LISTEN_ON_WILDCARD", False):
+        app.run(host='0.0.0.0')
+    else:
+        app.run()
 
 
 def create_app():


### PR DESCRIPTION
I found that, for development, I often have to make the standalone
server listen on 0.0.0.0 (instead of 127.0.0.1, which is the default) in
order to test the system with multiple agents.
