### PR TITLE
Don't reraise exception on unreachable agent

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -580,7 +580,6 @@ def poll_agent(self, agent_id):
             agent.state = AgentState.OFFLINE
             db.session.add(agent)
             db.session.commit()
-            raise
 
     else:
         present_task_ids = [x["id"] for x in json_data]


### PR DESCRIPTION
Reraising the exception at this points tends to clutter the log with
lengthy backtraces, especially in farms where many agents are not online
all the time.  Technically, the celery task was successful in that case,
too: The agent was polled, and found to be offline.
