### PR TITLE
Create user on job submit if unknown

### DIFF
--- a/pyfarm/master/api/jobs.py
+++ b/pyfarm/master/api/jobs.py
@@ -341,6 +341,7 @@ class JobIndexAPI(MethodView):
             if not user and AUTOCREATE_USERS:
                 user = User(username=username)
                 db.session.add(user)
+                logger.warning("User %s was autocreated on job submit", username)
             elif not user:
                 return (jsonify(
                     error="User %s not found" % username), NOT_FOUND)


### PR DESCRIPTION
Auto-created users will have no passwords and won't be able to log in.
