### PR TITLE
Limit requeues for task on failures, not attempts

### DIFF
--- a/pyfarm/models/task.py
+++ b/pyfarm/models/task.py
@@ -134,8 +134,7 @@ class Task(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
             return new_value
 
         if (new_value == WorkState.FAILED and
-            (target.attempts is None or
-             target.attempts <= target.job.requeue)):
+            target.failures <= target.job.requeue):
             logger.info("Failed task %s will be retried", target.id)
             target.agent_id = None
             return None


### PR DESCRIPTION
This way, a failed task that is being manually rerun will have its full
number of possible requeues again.
