### PR TITLE
Fix infinite loop in task_delete

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -492,7 +492,8 @@ def delete_task(self, task_id):
                                 job.id, job.title)
                     db.session.delete(job)
                 db.session.commit()
-                done = True
+            done = True
+
         except InvalidRequestError:
             if retries > 0:
                 logger.debug("Caught an InvalidRequestError trying to delete "


### PR DESCRIPTION
We are done with this loop even if we did not have to delete the job.
Only InvalidRequestErrors should make us repeat.
