### PR TITLE
Improve job notification mails

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -391,7 +391,7 @@ def send_job_completion_mail(job_id, successful=True):
     message_text += "Sincerely,\n\tThe PyFarm render manager"
 
     message = MIMEText(message_text)
-    message["Subject"] = ("Job %s %" %
+    message["Subject"] = ("Job %s %s" %
                             (job.title,
                              "completed successfully" if successful else
                              "failed"))


### PR DESCRIPTION
- Include the name of the jobtype in the notification mail. This is
  helpful when you have several jobs working on the same thing that are
  named the same or very similar.
- Change phrasing "completed unsuccessfully" to "failed".
