### PR TITLE
Track whether a task was sent out to the agent

### DIFF
--- a/pyfarm/master/api/agents.py
+++ b/pyfarm/master/api/agents.py
@@ -73,14 +73,15 @@ def fail_missing_assignments(agent, current_assignments):
 
     failed_tasks = []
     for task in tasks_query:
-        task.state = WorkState.FAILED
-        db.session.add(task)
-        failed_tasks.append(task)
-        logger.warning("Task %s (frame %s from job %r (%s)) was not in the "
-                       "current assignments of agent %r (id %s) when it should "
-                       "be.  Marking it as failed.",
-                       task.id, task.frame, task.job.title,
-                       task.job_id, agent.hostname, agent.id)
+        if task.sent_to_agent:
+            task.state = WorkState.FAILED
+            db.session.add(task)
+            failed_tasks.append(task)
+            logger.warning("Task %s (frame %s from job %r (%s)) was not in the "
+                           "current assignments of agent %r (id %s) when it "
+                           "should be.  Marking it as failed.",
+                           task.id, task.frame, task.job.title,
+                           task.job_id, agent.hostname, agent.id)
 
     return failed_tasks
 

--- a/pyfarm/models/task.py
+++ b/pyfarm/models/task.py
@@ -96,6 +96,9 @@ class Task(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
                                "won't run a given task.  This column will "
                                "be cleared whenever the task's state is "
                                "returned to a non-error state.")
+    sent_to_agent = db.Column(db.Boolean, default=False, nullable=False,
+                              doc="Whether this task was already sent to the "
+                                  "assigned agent")
 
     # relationships
     parents = db.relationship("Task",

--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -166,6 +166,11 @@ def send_tasks_to_agent(self, agent_id):
                                               requests.codes.created]:
                 raise ValueError("Unexpected return code on sending batch to "
                                  "agent: %s", response.status_code)
+            else:
+                for task in tasks:
+                    task.sent_to_agent = True
+                    db.session.add(task)
+                db.session.commit()
 
         except (ConnectionError, Timeout) as e:
             if self.request.retries < self.max_retries:
@@ -247,6 +252,7 @@ def assign_tasks_to_agent(agent_id):
                         batch = job.get_batch()
                         for task in batch:
                             task.agent = agent
+                            task.sent_to_agent = False
                             logger.info("Assigned agent %s (id %s) to task %s "
                                         "(frame %s) from job %s (id %s)",
                                         agent.hostname, agent.id, task.id,

--- a/tests/test_master/test_jobs_api.py
+++ b/tests/test_master/test_jobs_api.py
@@ -1045,7 +1045,8 @@ class TestJobAPI(BaseTestCase):
                                 "project_id": None,
                                 "state": "queued",
                                 "agent_id": None,
-                                "last_error": None
+                                "last_error": None,
+                                "sent_to_agent": False
                              },
                              {
                                 "hidden": False,
@@ -1061,7 +1062,8 @@ class TestJobAPI(BaseTestCase):
                                 "project_id": None,
                                 "state": "queued",
                                 "agent_id": None,
-                                "last_error": None
+                                "last_error": None,
+                                "sent_to_agent": False
                              }
                          ])
 
@@ -1117,7 +1119,8 @@ class TestJobAPI(BaseTestCase):
                                 "project_id": None,
                                 "state": "queued",
                                 "agent_id": None,
-                                "last_error": None
+                                "last_error": None,
+                                "sent_to_agent": False
                              },
                              {
                                 "hidden": False,
@@ -1133,7 +1136,8 @@ class TestJobAPI(BaseTestCase):
                                 "project_id": None,
                                 "state": "queued",
                                 "agent_id": None,
-                                "last_error": None
+                                "last_error": None,
+                                "sent_to_agent": False
                              }
                          ])
 
@@ -1205,7 +1209,8 @@ class TestJobAPI(BaseTestCase):
                             "project_id": None,
                             "state": "done",
                             "agent_id": None,
-                            "last_error": None
+                            "last_error": None,
+                            "sent_to_agent": False
                          })
 
         response5 = self.client.post(
@@ -1348,7 +1353,8 @@ class TestJobAPI(BaseTestCase):
                             "project_id": None,
                             "state": "queued",
                             "agent_id": None,
-                            "last_error": None
+                            "last_error": None,
+                            "sent_to_agent": False
                          })
 
         response5 = self.client.get("/api/v1/jobs/%s/tasks/%s" %
@@ -1374,7 +1380,8 @@ class TestJobAPI(BaseTestCase):
                             "project_id": None,
                             "state": "queued",
                             "agent_id": None,
-                            "last_error": None
+                            "last_error": None,
+                            "sent_to_agent": False
                          })
 
     def test_job_get_unknown_single_task(self):


### PR DESCRIPTION
This is supposed to fix a rae condition that can occur when an agent
reannounces itself in the time window between the scheduler assigning
a task to the agent and actually sending it to the agent.