### PR TITLE
Task log path needs to be resolved before use

### DIFF
--- a/pyfarm/master/api/tasklogs.py
+++ b/pyfarm/master/api/tasklogs.py
@@ -162,7 +162,7 @@ class LogsInTaskAttemptsIndexAPI(MethodView):
             return jsonify(task_id=task_id, job_id=job_id,
                            error="Specified task not found"), NOT_FOUND
 
-        path = join(LOGFILES_DIR, g.json["identifier"])
+        path = realpath(join(LOGFILES_DIR, g.json["identifier"]))
         if not realpath(path).startswith(LOGFILES_DIR):
             return jsonify(error="Identifier is not acceptable"), BAD_REQUEST
         task_log = TaskLog.query.filter_by(
@@ -294,7 +294,7 @@ class TaskLogfileAPI(MethodView):
             return jsonify(task_id=task.id, log=log.identifier,
                            error="Specified log not found in task"), NOT_FOUND
 
-        path = join(LOGFILES_DIR, log_identifier)
+        path = realpath(join(LOGFILES_DIR, log_identifier))
         if not realpath(path).startswith(LOGFILES_DIR):
             return jsonify(error="Identifier is not acceptable"), BAD_REQUEST
 
@@ -354,7 +354,7 @@ class TaskLogfileAPI(MethodView):
             return jsonify(task_id=task_id, log=log.identifier,
                            error="Specified log not found in task"), NOT_FOUND
 
-        path = join(LOGFILES_DIR, log_identifier)
+        path = realpath(join(LOGFILES_DIR, log_identifier))
         if not realpath(path).startswith(LOGFILES_DIR):
             return jsonify(error="Identifier is not acceptable"), BAD_REQUEST
 


### PR DESCRIPTION
`LOGFILES_DIR` and the identifier which forms `path` may contain symlinks.  When `realpath` runs it will fully resolve the path including symlinks.  This change ensures that we resolve `path` using `realpath` as well so even if there are symlinks present in `LOGFILES_DIR` the `startswith` check will operate properly.  I discovered this was broken while running the tests on a mac which symlinks `/tmp` by default.