### PR TITLE
Treat conflict as success on sending tasks

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -169,7 +169,8 @@ def send_tasks_to_agent(self, agent_id):
                 db.session.commit()
             elif response.status_code not in [requests.codes.accepted,
                                               requests.codes.ok,
-                                              requests.codes.created]:
+                                              requests.codes.created,
+                                              requests.codes.conflict]:
                 raise ValueError("Unexpected return code on sending batch to "
                                  "agent: %s", response.status_code)
             else:


### PR DESCRIPTION
An HTTP status code of 409 means that the agent already has the tasks in
question, so we might as well treat that as a success.