### PR TITLE
Fix deleting/rerunning a single job from jobs list

### DIFF
--- a/pyfarm/master/templates/pyfarm/user_interface/jobs.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/jobs.html
@@ -301,13 +301,13 @@
     <td>
 
       <form style="display: inline;" role="form" method="POST" action="{{ url_for('delete_single_job_ui', job_id=job[0].id, next=url_for('jobs_index_ui', **filters_and_order)) }}">
-        <label for="delete-job-submit" class="clickable-icon" title="Delete job"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></label>
-        <input id="delete-job-submit" type="submit" class="hidden" onclick="return confirm('Are you sure you want to delete this job?');"/>
+        <label for="delete-job-{{ job[0].id }}-submit" class="clickable-icon" title="Delete job"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></label>
+        <input id="delete-job-{{ job[0].id }}-submit" type="submit" class="hidden" onclick="return confirm('Are you sure you want to delete this job?');"/>
       </form>
 
       <form style="display: inline;" role="form" method="POST" action="{{ url_for('rerun_single_job_ui', job_id=job[0].id, next=url_for('jobs_index_ui', **filters_and_order)) }}">
-        <label for="rerun-job-submit" class="clickable-icon" title="Rerun job"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></label>
-        <input id="rerun-job-submit" type="submit" class="hidden" onclick="return confirm('Are you sure you want to rerun this job? This will include all tasks, even those already done.');"/>
+        <label for="rerun-job-{{ job[0].id }}-submit" class="clickable-icon" title="Rerun job"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></label>
+        <input id="rerun-job-{{ job[0].id }}-submit" type="submit" class="hidden" onclick="return confirm('Are you sure you want to rerun this job? This will include all tasks, even those already done.');"/>
       </form>
 
       {% if job[0].output_link %}


### PR DESCRIPTION
This bug would lead to rerun/delete actions for a single job to always
apply to the first job in the list instead of the one the user actually
clicked on.