### PR TITLE
Remove max-height from dropdown-menu-form class

### DIFF
--- a/pyfarm/master/static/css/job.css
+++ b/pyfarm/master/static/css/job.css
@@ -1,4 +1,3 @@
 ul.dropdown-menu-form {
     padding: 5px 10px 5px;
-    max-height: 300px;
 }

--- a/pyfarm/master/static/css/jobs.css
+++ b/pyfarm/master/static/css/jobs.css
@@ -1,6 +1,5 @@
 ul.dropdown-menu-form {
     padding: 5px 10px 5px;
-    max-height: 300px;
 }
 
 .job_progress {


### PR DESCRIPTION
This was necessary with Bootstrap 2 to avoid the disabled scrollbars,
but seems no longer necessary with Bootstrap 3