### PR TITLE
Use lock when sending notifies, track sent status

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -380,6 +380,7 @@ def rerun_single_job(job_id):
             db.session.add(task)
 
     job.state = None
+    job.completion_notify_sent = False
     db.session.add(job)
     db.session.commit()
 
@@ -410,6 +411,7 @@ def rerun_multiple_jobs():
                 db.session.add(task)
 
         job.state = None
+        job.completion_notify_sent = False
         db.session.add(job)
 
     db.session.commit()
@@ -438,6 +440,7 @@ def rerun_failed_in_job(job_id):
             db.session.add(task)
 
     job.state = None
+    job.completion_notify_sent = False
     db.session.add(job)
     db.session.commit()
 
@@ -468,6 +471,7 @@ def rerun_failed_in_multiple_jobs():
                 db.session.add(task)
 
         job.state = None
+        job.completion_notify_sent = False
         db.session.add(job)
         db.session.commit()
 

--- a/pyfarm/models/job.py
+++ b/pyfarm/models/job.py
@@ -263,6 +263,12 @@ class Job(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
                               doc="If true, the master will stop all running "
                                   "tasks for this job and then delete it.")
 
+    completion_notify_sent = db.Column(db.Boolean, nullable=False,
+                                       default=False,
+                                       doc="Whether or not the finish "
+                                           "notification mail has already "
+                                           "been sent out.")
+
     autodelete_time = db.Column(db.Integer, nullable=True, default=None,
                                 doc="If not None, this job will be "
                                     "automatically deleted this number of "

--- a/tests/test_master/test_jobs_api.py
+++ b/tests/test_master/test_jobs_api.py
@@ -189,7 +189,8 @@ class TestJobAPI(BaseTestCase):
                             "cpus": 1,
                             "children": [],
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                          })
 
     def test_job_post_with_notified_users(self):
@@ -262,7 +263,8 @@ class TestJobAPI(BaseTestCase):
                             "cpus": 1,
                             "children": [],
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                          })
 
     def test_job_post_bad_requirements(self):
@@ -529,7 +531,8 @@ class TestJobAPI(BaseTestCase):
                             "cpus": 1,
                             "children": [],
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                          })
 
     def test_job_post_unknown_type(self):
@@ -649,7 +652,8 @@ class TestJobAPI(BaseTestCase):
                             "children": [],
                             "by": 1.0,
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                         })
 
         response4 = self.client.get("/api/v1/jobs/%s" % id)
@@ -690,7 +694,8 @@ class TestJobAPI(BaseTestCase):
                             "children": [],
                             "by": 1.0,
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                         })
 
     def test_job_get_unknown(self):
@@ -769,7 +774,8 @@ class TestJobAPI(BaseTestCase):
                             "children": [],
                             "by": 1.0,
                             "to_be_deleted": False,
-                            "autodelete_time": None
+                            "autodelete_time": None,
+                            "completion_notify_sent": False
                         })
 
         response4 = self.client.post(


### PR DESCRIPTION
In spite of all the work that has gone into this in the past, our users
still keep seeing multiple notification emails for a single job.  This
patch should solve that for good.  It uses a combination of a database
field to track whether a notification has already been sent and a
filelock per job, so that even with low transaction isolation levels,
like "read committed", no races should occur.