### PR TITLE
Don't set max_batch to default on changing jobtype

### DIFF
--- a/pyfarm/master/user_interface/jobtypes.py
+++ b/pyfarm/master/user_interface/jobtypes.py
@@ -117,7 +117,7 @@ def remove_jobtype_software_requirement(jobtype_id, software_id):
                 jobtype_id), INTERNAL_SERVER_ERROR)
 
         new_version = JobTypeVersion(jobtype=jobtype)
-        new_version.max_batch = previous_version.max_batch
+        new_version.max_batch = previous_version.max_batch or sql.null()
         new_version.batch_contiguous = previous_version.batch_contiguous
         new_version.classname = previous_version.classname
         new_version.code = previous_version.code
@@ -156,7 +156,7 @@ def add_jobtype_software_requirement(jobtype_id):
                 jobtype_id), INTERNAL_SERVER_ERROR)
 
         new_version = JobTypeVersion(jobtype=jobtype)
-        new_version.max_batch = previous_version.max_batch
+        new_version.max_batch = previous_version.max_batch or sql.null()
         new_version.batch_contiguous = previous_version.batch_contiguous
         new_version.classname = previous_version.classname
         new_version.code = previous_version.code


### PR DESCRIPTION
There was a bug where changing the software requirements for a jobtype
would make max_batch be set to the default value (1) if it was
previously NULL. This fixes that.