### PR TITLE
Rework default software for agents

### DIFF
--- a/pyfarm/master/api/agents.py
+++ b/pyfarm/master/api/agents.py
@@ -58,8 +58,6 @@ from pyfarm.master.utility import (
 
 logger = getLogger("api.agents")
 
-DEFAULT_AGENT_SOFTWARE = json.loads(
-    read_env("PYFARM_DEFAULT_AGENT_SOFTWARE", "{}"))
 MAC_RE = re.compile("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
 
 
@@ -263,22 +261,9 @@ class AgentIndexAPI(MethodView):
             except ValueError as e:
                 return jsonify(error=str(e)), BAD_REQUEST
 
-            for item in DEFAULT_AGENT_SOFTWARE:
-                software = Software.query.filter_by(
-                    software=item["software"]).first()
-                if not software:
-                    return (jsonify(
-                        error="Default agent software %r not found" %
-                            item["software"]),
-                        INTERNAL_SERVER_ERROR)
-                version = SoftwareVersion.query.filter_by(
-                    software=software, version=item["version"]).first()
-                if not version:
-                    return (jsonify(
-                        error="Default agent software %r version %s not found" %
-                            (item["software"], item["version"])),
-                        INTERNAL_SERVER_ERROR)
-                agent.software_versions.append(version)
+            default_versions = SoftwareVersion.query.filter_by(default=True)
+            for version in default_versions:
+                 agent.software_versions.append(version)
 
             if mac_addresses is not None:
                 for address in mac_addresses:

--- a/pyfarm/master/entrypoints.py
+++ b/pyfarm/master/entrypoints.py
@@ -148,7 +148,8 @@ def load_user_interface(app_instance):
     from pyfarm.master.user_interface.logs_in_task import logs_in_task
     from pyfarm.master.user_interface.software import (
         software, software_item, update_version_rank, remove_software_version,
-        add_software_version, add_software, remove_software)
+        add_software_version, add_software, remove_software,
+        update_version_default_status)
 
     app_instance.add_url_rule("/agents/", "agents_index_ui", agents,
                               methods=("GET", ))
@@ -284,6 +285,11 @@ def load_user_interface(app_instance):
     app_instance.add_url_rule("/software/<int:software_id>/versions/"
                               "<int:version_id>/update_rank",
                               "version_update_rank_ui", update_version_rank,
+                              methods=("POST", ))
+    app_instance.add_url_rule("/software/<int:software_id>/versions/"
+                              "<int:version_id>/default_status",
+                              "version_update_default_ui",
+                              update_version_default_status,
                               methods=("POST", ))
     app_instance.add_url_rule("/software/<int:software_id>/versions/"
                               "<int:version_id>/remove",

--- a/pyfarm/master/templates/pyfarm/user_interface/software_item.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/software_item.html
@@ -12,7 +12,10 @@
     <th>
       Version
     </th>
-    <th>
+     <th>
+      Available On New Agents
+    </th>
+   <th>
       Rank
     </th>
   </tr>
@@ -26,6 +29,13 @@
     </td>
     <td>
       {{ version.version }}
+    </td>
+    <td>
+      <form method="post" action="/software/{{software.id}}/versions/{{version.id}}/default_status">
+        {{ version.default }}
+        <input type="hidden" name="default" value="{{ 'false' if version.default else 'true' }}"/>
+        <input type="submit" class="btn" value="Make{{' Not' if version.default }} Default"/>
+      </form>
     </td>
     <td>
       <form method="post" action="/software/{{software.id}}/versions/{{version.id}}/update_rank">

--- a/pyfarm/master/user_interface/software.py
+++ b/pyfarm/master/user_interface/software.py
@@ -186,3 +186,32 @@ def add_software_version(software_id):
 
     return redirect(url_for("single_software_ui", software_id=software.id),
                     SEE_OTHER)
+
+def update_version_default_status(software_id, version_id):
+    software = Software.query.filter_by(id=software_id).first()
+    if not software:
+        return (render_template("pyfarm/error.html",
+                                error="Software %s not found" % software_id),
+                NOT_FOUND)
+
+    version = SoftwareVersion.query.filter_by(
+        software=software, id=version_id).first()
+    if not version:
+        return redirect(url_for("single_software_ui", software_id=software.id),
+                    SEE_OTHER)
+
+    version.default = ("default" in request.form and
+                       request.form["default"] == "true")
+
+    db.session.add(version)
+    db.session.commit()
+
+    if version.default:
+        flash("Version %s has been added to the set of default software for new "
+              "agents." % version.version)
+    else:
+        flash("Version %s has been removed from the set of default software for "
+              "new agents." % version.version)
+
+    return redirect(url_for("single_software_ui", software_id=software.id),
+                    SEE_OTHER)

--- a/pyfarm/models/software.py
+++ b/pyfarm/models/software.py
@@ -87,6 +87,9 @@ class SoftwareVersion(db.Model, UtilityMixins):
                         The rank of this version relative to other versions of
                         the same software. Used to determine whether a version
                         is higher or lower than another."""))
+    default = db.Column(db.Boolean, default=False, nullable=False,
+                        doc="If true, this software version will be registered"
+                            "on new nodes by default.")
 
 
 class JobSoftwareRequirement(db.Model, UtilityMixins):


### PR DESCRIPTION
Software versions now have a "default" flag. If this is set, that
version will automatically be registered as available on all new agents.

This should be more user friendly and less prone to error than the
previous solution to this problem, since now a user cannot specify a
version that doesn't even exist as a default.