### PR TITLE
Get task.agent before setting task state

### DIFF
--- a/pyfarm/master/api/jobs.py
+++ b/pyfarm/master/api/jobs.py
@@ -1111,6 +1111,7 @@ class JobSingleTaskAPI(MethodView):
             return jsonify(error="`frame` cannot be changed"), BAD_REQUEST
 
         new_state = g.json.pop("state", None)
+        agent = task.agent
         state_transition = False
         if new_state is not None and new_state != task.state:
             logger.info("Task %s of job %s: state transition \"%s\" -> \"%s\"",
@@ -1154,8 +1155,7 @@ class JobSingleTaskAPI(MethodView):
         logger.info("Task %s of job %s has been updated, new data: %r",
                     task_id, task.job.title, task_data)
 
-        if task.agent:
-            agent = task.agent
+        if agent:
             task_count = Task.query.filter(
                 Task.agent == agent,
                 or_(Task.state == None,


### PR DESCRIPTION
After setting the task's state, task.agent might no longer be set to the
original agent, especially if the task failed.

This avoids a problem where the master would fail to assign a new task
to an agent that has just had a task fail.