### PR TITLE
Ignore agent state "running" for scheduling

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -286,8 +286,8 @@ def restart_agent(self, agent_id):
 @celery_app.task(ignore_result=True)
 def assign_tasks():
     db.session.rollback()
-    idle_agents = Agent.query.filter(Agent.state._in([AgentState.ONLINE,
-                                                      AgentState.RUNNING]),
+    idle_agents = Agent.query.filter(or_(Agent.state == AgentState.ONLINE,
+                                         Agent.state == AgentState.RUNNING),
                                      ~Agent.tasks.any(
                                         or_(
                                         Task.state == None,

--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -286,7 +286,8 @@ def restart_agent(self, agent_id):
 @celery_app.task(ignore_result=True)
 def assign_tasks():
     db.session.rollback()
-    idle_agents = Agent.query.filter(Agent.state == AgentState.ONLINE,
+    idle_agents = Agent.query.filter(Agent.state._in([AgentState.ONLINE,
+                                                      AgentState.RUNNING]),
                                      ~Agent.tasks.any(
                                         or_(
                                         Task.state == None,


### PR DESCRIPTION
The agent state "running" is not a reliable indicator.  Sometimes,
especially when an assignment was done very fast, the agent may fail to
reset its status to online again.