### PR TITLE
Upgrade SQLAlchemy Dependency to >=0.9.9

### DIFF
--- a/pyfarm/models/core/types.py
+++ b/pyfarm/models/core/types.py
@@ -335,7 +335,7 @@ class UUIDType(TypeDecorator):
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":
-            return dialect.type_descriptor(POSTGRES_UUID())
+            return dialect.type_descriptor(POSTGRES_UUID(as_uuid=True))
 
         return dialect.type_descriptor(VARBINARY(16))
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 #   flask-admin: New form helps that support async JavaScript requests
 install_requires = [
     "pyfarm.core>=0.9.1",
-    "sqlalchemy>=0.9.3",
+    "sqlalchemy==0.9.8",
     "flask",
     "flask-login",
     "flask-sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 #   flask-admin: New form helps that support async JavaScript requests
 install_requires = [
     "pyfarm.core>=0.9.1",
-    "sqlalchemy==0.9.8",
+    "sqlalchemy>=0.9.9",
     "flask",
     "flask-login",
     "flask-sqlalchemy",


### PR DESCRIPTION
In response to #384, we should upgrade the sqlalchemy version to `>=0.9.9`.  This will ensure that anyone someone install the master they can't end up with a broken dependency.