### PR TITLE
Merge events when adding existing notified user

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -764,13 +764,19 @@ def add_notified_user_to_job(job_id):
                     "pyfarm/error.html", error="User %s not found" % user_id),
                 NOT_FOUND)
 
-    notified_user = JobNotifiedUser(user=user, job=job)
-    notified_user.on_success = ("on_success" in request.form and
-                                request.form["on_success"] == "true")
-    notified_user.on_failure = ("on_failure" in request.form and
-                                request.form["on_failure"] == "true")
-    notified_user.on_deletion = ("on_deletion" in request.form and
-                                 request.form["on_deletion"] == "true")
+    notified_user = JobNotifiedUser.query.filter_by(user=user, job=job).first()
+    if not notified_user:
+        notified_user = JobNotifiedUser(user=user, job=job)
+
+    notified_user.on_success = (("on_success" in request.form and
+                                 request.form["on_success"] == "true") or
+                                notified_user.on_success)
+    notified_user.on_failure = (("on_failure" in request.form and
+                                 request.form["on_failure"] == "true") or
+                                notified_user.on_failure)
+    notified_user.on_deletion = (("on_deletion" in request.form and
+                                  request.form["on_deletion"] == "true") or
+                                 notified_user.on_deletion)
 
     db.session.add(notified_user)
     db.session.commit()


### PR DESCRIPTION
Trying to add a notified user to a job that already existed on that job would lead to an internal server error. Instead  of trying to insert a new notified user record where one already exists – and running into another unique constraint violation –  the code will now update the existing record instead.