### PR TITLE
Update job state after deleting a task

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -808,6 +808,9 @@ def delete_task(self, task_id):
                              task_id, TRANSACTION_RETRIES)
                 raise
 
+    job.update_state()
+    db.session.commit()
+
     retries = TRANSACTION_RETRIES
     done = False
     while not done and retries > 0:


### PR DESCRIPTION
This should fix a problem where jobs a not set top "done" after a task
is removed through "alter frame selection", and all remaining tasks are
already done.