### PR TITLE
Track result state for every attempt for tasks

### DIFF
--- a/pyfarm/master/templates/pyfarm/user_interface/agent.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/agent.html
@@ -174,6 +174,7 @@
   <thead>
     <th>Identifier</th>
     <th>Created On</th>
+    <th>Tasks (Queued / Running / Failed / Done)</th>
     <th>Job</th>
     <th>Jobtype</th>
   </thead>
@@ -182,6 +183,12 @@
     <tr>
       <td>{% if tasklog.task %}<a href="/api/v1/jobs/{{ tasklog.task.job.id }}/tasks/{{ tasklog.task.id }}/attempts/{{ tasklog.attempt }}/logs/{{ tasklog.identifier }}/logfile">{% endif %}{{ tasklog.identifier }}{% if tasklog.task %}</a>{% endif %}</td>
       <td class="timestamp">{{ tasklog.created_on.isoformat() }}</td>
+      <td>
+        {{ tasklog.num_queued_tasks() }} /
+        {{ tasklog.num_running_tasks() }} /
+        {{ tasklog.num_failed_tasks() }} /
+        {{ tasklog.num_done_tasks() }}
+      </td>
       <td>
         {% if tasklog.task %}
         <a href="{{ url_for('single_job_ui', job_id=tasklog.task.job.id) }}">{{ tasklog.task.job.title }}</a>

--- a/pyfarm/master/templates/pyfarm/user_interface/logs_in_task.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/logs_in_task.html
@@ -12,7 +12,16 @@
   <li> Attempt {{ attempt }}
     <ul>
     {% for log in logs %}
-      <li><span class="timestamp">{{ log.log.created_on.isoformat() }}</span> on {{ log.log.agent.hostname }}: <a href="/api/v1/jobs/{{ task.job.id }}/tasks/{{ task.id }}/attempts/{{ attempt }}/logs/{{ log.log.identifier }}/logfile">{{ log.log.identifier }}</a></li>
+      <li>
+        <span class="timestamp">{{ log.log.created_on.isoformat() }}</span>
+        on {{ log.log.agent.hostname }}:
+        <a href="/api/v1/jobs/{{ task.job.id }}/tasks/{{ task.id }}/attempts/{{ attempt }}/logs/{{ log.log.identifier }}/logfile">{{ log.log.identifier }}</a>
+        – Tasks:
+        {{ log.log.num_queued_tasks() }} /
+        {{ log.log.num_running_tasks() }} /
+        {{ log.log.num_failed_tasks() }} /
+        {{ log.log.num_done_tasks() }}
+      </li>
     {% endfor %}
     </ul>
   </li>

--- a/pyfarm/models/tasklog.py
+++ b/pyfarm/models/tasklog.py
@@ -30,6 +30,7 @@ from datetime import datetime
 
 from sqlalchemy.schema import UniqueConstraint, PrimaryKeyConstraint
 
+from pyfarm.core.enums import WorkState
 from pyfarm.models.core.types import WorkStateEnum
 from pyfarm.master.application import db
 from pyfarm.models.core.mixins import ReprMixin, UtilityMixins
@@ -72,3 +73,19 @@ class TaskLog(db.Model, UtilityMixins, ReprMixin):
                                 "created on")
     task_associations = db.relationship(TaskTaskLogAssociation,
                                         backref="log")
+
+    def num_queued_tasks(self):
+        return TaskTaskLogAssociation.query.filter_by(
+            log=self, state=None).count()
+
+    def num_running_tasks(self):
+        return TaskTaskLogAssociation.query.filter_by(
+            log=self, state=WorkState.RUNNING).count()
+
+    def num_failed_tasks(self):
+        return TaskTaskLogAssociation.query.filter_by(
+            log=self, state=WorkState.FAILED).count()
+
+    def num_done_tasks(self):
+        return TaskTaskLogAssociation.query.filter_by(
+            log=self, state=WorkState.DONE).count()

--- a/pyfarm/models/tasklog.py
+++ b/pyfarm/models/tasklog.py
@@ -30,6 +30,7 @@ from datetime import datetime
 
 from sqlalchemy.schema import UniqueConstraint, PrimaryKeyConstraint
 
+from pyfarm.models.core.types import WorkStateEnum
 from pyfarm.master.application import db
 from pyfarm.models.core.mixins import ReprMixin, UtilityMixins
 from pyfarm.models.core.types import id_column, IDTypeAgent, IDTypeWork
@@ -44,6 +45,8 @@ class TaskTaskLogAssociation(db.Model):
     task_id = db.Column(IDTypeWork, db.ForeignKey("%s.id" % TABLE_TASK,
                                                   ondelete="CASCADE"))
     attempt = db.Column(db.Integer, autoincrement=False)
+
+    state = db.Column(WorkStateEnum, nullable=True)
 
     task = db.relationship("Task", backref=db.backref("log_associations",
                                                       lazy="dynamic",


### PR DESCRIPTION
This should later make it easier to identify nodes that have problems
with certain jobtypes.