### PR TITLE
Fix changing the subjobs toggle icon on toggling

### DIFF
--- a/pyfarm/master/static/js/jobs.js
+++ b/pyfarm/master/static/js/jobs.js
@@ -3,8 +3,8 @@ $(document).ready(function() {
         var open = $(this).data("open") == "true";
         if(!open) {
             $(this).data("open", "true")
-            $(this).removeClass("icon-circle-arrow-down")
-            $(this).addClass("icon-circle-arrow-up")
+            $(this).removeClass("glyphicon-circle-arrow-down")
+            $(this).addClass("glyphicon-circle-arrow-up")
             var jobid = $(this).data("jobid");
             var subjob_table = $(
                 "<table class='table table-striped table-bordered subjob-table'>"+
@@ -28,8 +28,8 @@ $(document).ready(function() {
         }
         else {
             $(this).data("open", "false");
-            $(this).removeClass("icon-circle-arrow-up")
-            $(this).addClass("icon-circle-arrow-down")
+            $(this).removeClass("glyphicon-circle-arrow-up")
+            $(this).addClass("glyphicon-circle-arrow-down")
             $(this).closest("tr").find("table.subjob-table").remove();
         }
     });


### PR DESCRIPTION
This was broken by the upgrade to Bootstrap 3, because the class names
for icons had changed.