### PR TITLE
Remove login check for top level links

### DIFF
--- a/pyfarm/master/templates/pyfarm/user_interface/layout.html
+++ b/pyfarm/master/templates/pyfarm/user_interface/layout.html
@@ -30,7 +30,6 @@
           <a class="navbar-brand" href="#">PyFarm {{farm_name}}</a>
           </div>
           <div class="collapse navbar-collapse" id="pyfarm-navbar-collapse-1">
-            {% if not current_user.is_anonymous() %}
             <ul class="nav navbar-nav">
               <li class="{% block agents_nb_class %}{% endblock %}"><a href="{{ url_for('agents_index_ui') }}">Agents</a></li>
               <li class="{% block jobs_nb_class %}{% endblock %}"><a href="{{ url_for('jobs_index_ui') }}">Jobs</a></li>
@@ -38,7 +37,6 @@
               <li class="{% block jobtypes_nb_class %}{% endblock %}"><a href="{{ url_for('jobtypes_index_ui')}}">Jobtypes</a></li>
               <li class="{% block software_nb_class %}{% endblock %}"><a href="{{ url_for('software_index_ui')}}">Software</a></li>
             </ul>
-            {% endif %}
             <ul class="nav navbar-nav navbar-right">
               {% if current_user.is_anonymous() %}
               <li><a href="/login">Login</a></li>


### PR DESCRIPTION
This way, all visitors, even those not logged in, will be able to the
top-level links to agents, jobs and so on.

Rationale: We do not have working authorization checks for the pages
anyway. If someone simply adds /jobs/ to the URL, they can view the jobs
list anyway. As it stands right now, this check is just a minor
annoyance at best and at worst will give users a false sense of
security.

We can readd this check once we do have real authorization.