### PR TITLE
Lock off SQLAlchemy to < 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ from setuptools import setup
 # Version requirements explanations:
 #   pyfarm.core: certain enums which are only present in later versions,
 #   configuration loader changes
-#   sqlalchemy: Bugfix for pymysql in Python 3
+#   sqlalchemy: Bugfix for pymysql in Python 3 and locking off from 1.x for now
 #   flask-admin: New form helps that support async JavaScript requests
 install_requires = [
     "pyfarm.core>=0.9.1",
-    "sqlalchemy>=0.9.9",
+    "sqlalchemy>=0.9.9,<1.0.0",
     "flask",
     "flask-login",
     "flask-sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 #   flask-admin: New form helps that support async JavaScript requests
 install_requires = [
     "pyfarm.core>=0.9.1",
-    "sqlalchemy>=0.9.9,<1.0.0",
+    "sqlalchemy>=0.9.9",
     "flask",
     "flask-login",
     "flask-sqlalchemy",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 #   flask-admin: New form helps that support async JavaScript requests
 install_requires = [
     "pyfarm.core>=0.9.1",
-    "sqlalchemy>=0.9.9",
+    "sqlalchemy>=0.9.9,<1.0.0",
     "flask",
     "flask-login",
     "flask-sqlalchemy",


### PR DESCRIPTION
SQLAlchemy 1.0.0 was released today and in our case it seems to have broken things:

https://travis-ci.org/pyfarm/pyfarm-master/builds/58849576

We should still investigate and fix the problem but for now I propose we lock down the upper range of our sqlalchemy version so installing from master does not break anything.