### PR TITLE
Determine correct state for job after resume

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -587,6 +587,8 @@ def unpause_single_job(job_id):
     db.session.add(job)
     db.session.commit()
 
+    assign_tasks.delay()
+
     flash("Job %s is unpaused." % job.title)
 
     if "next" in request.args:
@@ -609,6 +611,8 @@ def unpause_multiple_jobs():
         db.session.add(job)
 
     db.session.commit()
+
+    assign_tasks.delay()
 
     flash("Selected jobs are unpaused")
 

--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -583,6 +583,7 @@ def unpause_single_job(job_id):
                 NOT_FOUND)
 
     job.state = None
+    job.update_state()
     db.session.add(job)
     db.session.commit()
 
@@ -604,6 +605,7 @@ def unpause_multiple_jobs():
                     NOT_FOUND)
 
         job.state = None
+        job.update_state()
         db.session.add(job)
 
     db.session.commit()


### PR DESCRIPTION
Without this fix, pausing and then resuming a job that was already
failed or done would set the job back to queued.