### PR TITLE
Actually read the agent's state when polling

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -502,6 +502,9 @@ def poll_agent(self, agent_id):
                     (agent.hostname, agent.id, status_json["farm_name"],
                      OUR_FARM_NAME))
 
+        agent.state = status_json["state"]
+        agent.free_ram = status_json["free_ram"]
+
         tasks_response = requests.get(
             agent.api_url() + "/tasks/",
             headers={"User-Agent": USERAGENT},


### PR DESCRIPTION
Without this, the master will fail to set an agent marked as offline
back to online or running even if it could successfully contact it.