### PR TITLE
Always use Job/Agent id as secondary order key

### DIFF
--- a/pyfarm/master/user_interface/agents.py
+++ b/pyfarm/master/user_interface/agents.py
@@ -93,6 +93,7 @@ def agents():
                 "pyfarm/error.html", error="unknown order dir"), BAD_REQUEST)
 
     agents_query = agents_query.order_by("%s %s" % (order_by, order_dir))
+    agents_query = agents_query.order_by(Agent.id)
 
     agents_count = agents_query.count()
     online_agents_count = agents_query.filter(

--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -266,6 +266,8 @@ def jobs():
     else:
         jobs_query = jobs_query.order_by("%s %s" % (order_by, order_dir))
 
+    jobs_query = jobs_query.order_by(Job.id)
+
     jobs_count = jobs_query.count()
     queued_jobs_count = jobs_query.filter(Job.state == None).count()
     running_jobs_count = jobs_query.filter(


### PR DESCRIPTION
When ordering agents or jobs by non-unique keys, the ordering of items
with equal values for that key among themselves is not stable, and may
change between requests.  This breaks pagination.  By always using the
id as a secondary order key, we can avoid that problem.