### PR TITLE
Refactor rerun and rerun failed for jobs

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -435,18 +435,8 @@ def rerun_single_job(job_id):
                     "pyfarm/error.html", error="Job %s not found" % job_id),
                 NOT_FOUND)
 
-    for task in job.tasks:
-        if task.state != WorkState.RUNNING:
-            task.state = None
-            task.agent = None
-            task.failures = 0
-            db.session.add(task)
-
-    job.state = None
-    job.completion_notify_sent = False
-    db.session.add(job)
+    job.rerun()
     db.session.commit()
-
     assign_tasks.delay()
 
     flash("Job %s will be run again." % job.title)
@@ -465,20 +455,9 @@ def rerun_multiple_jobs():
             return (render_template(
                         "pyfarm/error.html", error="Job %s not found" % job_id),
                     NOT_FOUND)
-
-        for task in job.tasks:
-            if task.state != WorkState.RUNNING:
-                task.state = None
-                task.agent = None
-                task.failures = 0
-                db.session.add(task)
-
-        job.state = None
-        job.completion_notify_sent = False
-        db.session.add(job)
+        job.rerun()
 
     db.session.commit()
-
     assign_tasks.delay()
 
     flash("Selected jobs will be run again.")
@@ -495,16 +474,7 @@ def rerun_failed_in_job(job_id):
                     "pyfarm/error.html", error="Job %s not found" % job_id),
                 NOT_FOUND)
 
-    for task in job.tasks:
-        if task.state == _WorkState.FAILED:
-            task.state = None
-            task.agent = None
-            task.failures = 0
-            db.session.add(task)
-
-    job.state = None
-    job.completion_notify_sent = False
-    db.session.add(job)
+    job.rerun_failed()
     db.session.commit()
 
     assign_tasks.delay()
@@ -526,16 +496,7 @@ def rerun_failed_in_multiple_jobs():
                         "pyfarm/error.html", error="Job %s not found" % job_id),
                     NOT_FOUND)
 
-        for task in job.tasks:
-            if task.state == _WorkState.FAILED:
-                task.state = None
-                task.agent = None
-                task.failures = 0
-                db.session.add(task)
-
-        job.state = None
-        job.completion_notify_sent = False
-        db.session.add(job)
+        job.rerun_failed()
         db.session.commit()
 
     assign_tasks.delay()

--- a/pyfarm/models/job.py
+++ b/pyfarm/models/job.py
@@ -547,6 +547,36 @@ class Job(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
             if self.state != WorkState.RUNNING:
                 self.state = None
 
+    def rerun(self):
+        running_tasks = False
+        for task in self.tasks:
+            if task.state != _WorkState.RUNNING and task.state is not None:
+                task.state = None
+                task.agent = None
+                task.failures = 0
+                db.session.add(task)
+            elif task.state == _WorkState.RUNNING or task.agent is not None:
+                running_tasks = True
+
+        if not running_tasks:
+            self.state = None
+        else:
+            self.state = WorkState.RUNNING
+        self.completion_notify_sent = False
+        db.session.add(self)
+
+    def rerun_failed(self):
+        for task in self.tasks:
+            if task.state == _WorkState.FAILED:
+                task.state = None
+                task.agent = None
+                task.failures = 0
+                db.session.add(task)
+
+        self.state = None
+        self.completion_notify_sent = False
+        db.session.add(self)
+
     @validates("ram", "cpus")
     def validate_resource(self, key, value):
         """

--- a/pyfarm/models/job.py
+++ b/pyfarm/models/job.py
@@ -548,6 +548,10 @@ class Job(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
                 self.state = None
 
     def rerun(self):
+        """
+        Makes this job rerun all its task.  Tasks that are currently running are
+        left untouched.
+        """
         running_tasks = False
         for task in self.tasks:
             if task.state != _WorkState.RUNNING and task.state is not None:
@@ -566,6 +570,10 @@ class Job(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
         db.session.add(self)
 
     def rerun_failed(self):
+        """
+        Makes this job rerun all its failed tasks.  Tasks that are done or are
+        currently running are left untouched
+        """
         for task in self.tasks:
             if task.state == _WorkState.FAILED:
                 task.state = None


### PR DESCRIPTION
This turns rerun and rerun_failed into methods in the job class,
making this a bit more object oriented and avoiding some code
duplication.