### PR TITLE
Fix stopping the tasks when pausing multiple jobs

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -592,7 +592,7 @@ def pause_multiple_jobs():
     db.session.commit()
 
     for task_id in task_ids_to_stop:
-        stop_task.delay(task.id)
+        stop_task.delay(task_id)
     assign_tasks.delay()
 
     flash("Selected jobs will be paused.")


### PR DESCRIPTION
We were using the wrong variable for the task id