### PR TITLE
Reformat Models: JobGroup

### DIFF
--- a/pyfarm/models/jobgroup.py
+++ b/pyfarm/models/jobgroup.py
@@ -1,6 +1,7 @@
 # No shebang line, this module is meant to be imported
 #
 # Copyright 2015 Ambient Entertainment GmbH & Co. KG
+# Copyright 2015 Oliver Palmer
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,11 +21,13 @@ Job Group Model
 
 Model for job groups
 """
+
 from pyfarm.master.application import db
 from pyfarm.models.core.cfg import (
     TABLE_JOB_GROUP, TABLE_JOB_TYPE, TABLE_USER, MAX_JOBGROUP_NAME_LENGTH)
 from pyfarm.models.core.mixins import UtilityMixins
 from pyfarm.models.core.types import id_column, IDTypeWork
+
 
 class JobGroup(db.Model, UtilityMixins):
     """
@@ -33,21 +36,36 @@ class JobGroup(db.Model, UtilityMixins):
     __tablename__ = TABLE_JOB_GROUP
 
     id = id_column(IDTypeWork)
-    title = db.Column(db.String(MAX_JOBGROUP_NAME_LENGTH), nullable=False)
-    main_jobtype_id = db.Column(IDTypeWork,
-                                db.ForeignKey("%s.id" % TABLE_JOB_TYPE),
-                                nullable=False,
-                                doc="ID of the jobtype of the main job in this "
-                                    "group. Purely for display and "
-                                    "filtering.")
-    user_id = db.Column(db.Integer, db.ForeignKey("%s.id" % TABLE_USER),
-                        doc="The id of the user who owns these jobs")
-    main_jobtype = db.relationship("JobType",
-                                   backref=db.backref("jobgroups",
-                                                      lazy="dynamic"),
-                                   doc="The jobtype of the main job in this "
-                                       "group")
-    user = db.relationship("User",
-                           backref=db.backref("jobgroups",
-                                              lazy="dynamic"),
-                           doc="The user who owns these jobs")
+
+    title = db.Column(
+        db.String(MAX_JOBGROUP_NAME_LENGTH),
+        nullable=False,
+        doc="The title of the job group's name"
+    )
+
+    main_jobtype_id = db.Column(
+        IDTypeWork,
+        db.ForeignKey("%s.id" % TABLE_JOB_TYPE),
+        nullable=False,
+        doc="ID of the jobtype of the main job in this "
+            "group. Purely for display and filtering.")
+
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("%s.id" % TABLE_USER),
+        doc="The id of the user who owns these jobs"
+    )
+
+    #
+    # Relationships
+    #
+    main_jobtype = db.relationship(
+        "JobType",
+        backref=db.backref("jobgroups", lazy="dynamic"),
+        doc="The jobtype of the main job in this group")
+
+    user = db.relationship(
+        "User",
+        backref=db.backref("jobgroups", lazy="dynamic"),
+        doc="The user who owns these jobs"
+    )

--- a/pyfarm/models/jobgroup.py
+++ b/pyfarm/models/jobgroup.py
@@ -40,8 +40,7 @@ class JobGroup(db.Model, UtilityMixins):
     title = db.Column(
         db.String(MAX_JOBGROUP_NAME_LENGTH),
         nullable=False,
-        doc="The title of the job group's name"
-    )
+        doc="The title of the job group's name")
 
     main_jobtype_id = db.Column(
         IDTypeWork,
@@ -53,8 +52,7 @@ class JobGroup(db.Model, UtilityMixins):
     user_id = db.Column(
         db.Integer,
         db.ForeignKey("%s.id" % TABLE_USER),
-        doc="The id of the user who owns these jobs"
-    )
+        doc="The id of the user who owns these jobs")
 
     #
     # Relationships
@@ -67,5 +65,4 @@ class JobGroup(db.Model, UtilityMixins):
     user = db.relationship(
         "User",
         backref=db.backref("jobgroups", lazy="dynamic"),
-        doc="The user who owns these jobs"
-    )
+        doc="The user who owns these jobs")


### PR DESCRIPTION
This reformats the JobGroup table to match others which are currently in master.  This should be merged before #420 for consistency.