### PR TITLE
Allow setting a task's time_started to now via API

### DIFF
--- a/pyfarm/master/api/jobs.py
+++ b/pyfarm/master/api/jobs.py
@@ -24,6 +24,7 @@ This module defines an API for managing and querying jobs
 
 from decimal import Decimal
 from json import loads
+from datetime import datetime
 
 try:
     from httplib import (
@@ -1099,9 +1100,11 @@ class JobSingleTaskAPI(MethodView):
         if not task:
             return jsonify(error="Task not found"), NOT_FOUND
 
-        if "time_started" in g.json:
+        if "time_started" in g.json and g.json["time_started"] != "now":
             return (jsonify(error="`time_started` cannot be set manually"),
                     BAD_REQUEST)
+        elif "time_started" in g.json and g.json["time_started"] == "now":
+            g.json["time_started"] = datetime.utcnow()
 
         if "time_finished" in g.json:
             return (jsonify(error="`time_finished` cannot be set manually"),


### PR DESCRIPTION
This is useful for batch assignments. In batch assignments, the jobtype code will usually scan the process's output and set tasks to done as soon as they are done, but until now, it cannot reset the time_started value for a task, meaning all tasks in an assignment have the same start time. This in turn means that later tasks in an assignment will show a runtime that is the sum of their actual runtime plus the runtimes of all the tasks from the same assignment that were run before.