### PR TITLE
Update the current job's state after CONFLICT

### DIFF
--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -250,6 +250,8 @@ def send_tasks_to_agent(self, agent_id):
                             task.agent = None
                             task.attempts -= 1
                             db.session.add(task)
+                    db.session.flush()
+                    job.update_state()
                     db.session.commit()
                 else:
                     logger.error("CONFLICT response from agent %s (id %s) did "


### PR DESCRIPTION
If the task(s) in question were the only tasks left for this job, a 409
from an agent may leave it with no tasks running, in which case the
job's state needs to be reset.