### PR TITLE
Revert bd2e7a8

### DIFF
--- a/pyfarm/master/user_interface/jobs.py
+++ b/pyfarm/master/user_interface/jobs.py
@@ -1035,7 +1035,7 @@ def update_tag_requirements_in_job(job_id):
                 NOT_FOUND)
 
     tagnames = request.form["tag_requirements"].split(" ")
-    tagnames = filter(bool, map(str.strip, tagnames))
+    tagnames = [x.strip() for x in tagnames if not x == ""]
     job.tag_requirements = []
     for name in tagnames:
         negate = False


### PR DESCRIPTION
This code does not work properly in Python 2, because the tag names may
be passed as unicode objects instead os str objects.