### PR TITLE
Don't set time_started before process has started

### DIFF
--- a/pyfarm/models/task.py
+++ b/pyfarm/models/task.py
@@ -189,7 +189,8 @@ class Task(db.Model, ValidatePriorityMixin, ValidateWorkStateMixin,
                 target.time_started = datetime.utcnow()
             target.time_finished = None
 
-        elif new_value in (_WorkState.DONE, _WorkState.FAILED):
+        elif (new_value in (_WorkState.DONE, _WorkState.FAILED) and
+              not target.time_finished):
             target.time_finished = datetime.utcnow()
 
 event.listen(Task.state, "set", Task.clear_error_state)

--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -414,7 +414,6 @@ def assign_tasks_to_agent(agent_id):
                         for task in batch:
                             task.agent = agent
                             task.sent_to_agent = False
-                            task.time_started = None
                             logger.info("Assigned agent %s (id %s) to task %s "
                                         "(frame %s) from job %s (id %s)",
                                         agent.hostname, agent.id, task.id,


### PR DESCRIPTION
This avoids resetting time_started and time_finished for a task that was
restarted and is essentially skipped on the next attempt without any
render process actually being started.