### PR TITLE
Fix the display of logs in error mails

### DIFF
--- a/pyfarm/scheduler/etc/scheduler.yml
+++ b/pyfarm/scheduler/etc/scheduler.yml
@@ -190,10 +190,10 @@ failed_body:
   {{ job.output_link }}
   {% endif %}
 
-  {% if failed_logs %}
+  {% if failed_log_urls %}
   Log(s) for failed tasks:
-  {% for log in failed_logs %}
-  {{log.url}}
+  {% for url in failed_log_urls %}
+  {{url}}
   {% endfor%}
   {% endif %}
 

--- a/pyfarm/scheduler/tasks.py
+++ b/pyfarm/scheduler/tasks.py
@@ -726,7 +726,7 @@ def send_job_completion_mail(job_id, successful=True):
                 if last_log_assoc:
                     log = last_log_assoc.log
                     log_url = BASE_URL
-                    if log_url[-1] != "/":
+                    if not log_url.endswith("/"):
                         log_url += "/"
                     log_url += ("api/v1/jobs/%s/tasks/%s/attempts/%s/"
                                 "logs/%s/logfile" %


### PR DESCRIPTION
Since often several tasks refer to the same task log, we were sometimes
working on the same log object repeatedly, overwriting the existing url.